### PR TITLE
Handle failed trajectory in connect stage

### DIFF
--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -161,7 +161,13 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 
 		robot_trajectory::RobotTrajectoryPtr trajectory;
 		success = pair.second->plan(start, end, jmg, timeout, trajectory, path_constraints);
-		sub_trajectories.push_back(trajectory);  // include failed trajectory
+
+		if (success) {
+			sub_trajectories.push_back(trajectory);  
+		}
+		else {
+			sub_trajectories.push_back(nullptr); 
+		}
 
 		if (!success)
 			break;

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -162,10 +162,12 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 		robot_trajectory::RobotTrajectoryPtr trajectory;
 		success = pair.second->plan(start, end, jmg, timeout, trajectory, path_constraints);
 
+		// Do not push partial solutions
 		if (success) {
 			sub_trajectories.push_back(trajectory);  
 		}
 		else {
+			// Pushing a nullptr instead of a failed trajectory. 
 			sub_trajectories.push_back(nullptr); 
 		}
 


### PR DESCRIPTION
The Pick and Place objective displayed discontinuities in the trajectory and this was scoped to be a potential culprit by Henning. 
